### PR TITLE
Move Activity into gks-common, and update Contribution accordingly

### DIFF
--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -108,9 +108,41 @@ $defs:
       - id
       - type
 
+  Activity:
+    inherits: gks.core:Entity
+    maturity: draft
+    description: >-
+      An action or set of actions performed by an agent, that occurs over a period of time. Activities may use,
+      generate, modify, move, or destroy one or more entities.
+    heritableProperties:
+      subtype:
+        type:
+          $refCurie: gks.core:Coding
+        description: A more specific type of activity that an Activity object may represent.
+      date:
+        type: string
+        format: date
+        description: >-
+          The date that the Activity was completed. The date SHOULD be formatted as a date string
+          in ISO format "YYYY-MM-DD".
+      performedBy:
+        type: array
+        ordered: false
+        items:
+          $refCurie: gks.core:Agent
+        description: >-
+          An Agent who contributed to executing the Activity.
+      specifiedBy:
+        type: array
+        ordered: false
+        items:
+          $refCurie: gks.core:Method
+        description: >-
+          A method that was followed in performing an Activity, that describes how it was executed.
+
   Contribution:
     type: object
-    inherits: Entity
+    inherits: Activity
     maturity: draft
     description: >-
       An action taken by an agent in contributing to the creation, modification, assessment, or
@@ -122,19 +154,11 @@ $defs:
         default: Contribution
         description: MUST be "Contribution".
       contributor:
+        extends: performedBy
         $ref: "#/$defs/Agent"
         description: >-
           The agent that made the contribution.
-      date:
-        type: string
-        format: date
-        description: >-
-          The date on which the contribution was made. The date SHOULD be formatted as a date string
-          in ISO format "YYYY-MM-DD".
-      contributionMadeTo:
-        $ref: "#/$defs/InformationEntity"
-        description: The artifact toward which the contribution was made.
-      activity:
+      activityType:
         $ref: "#/$defs/Coding"
         description: >-
           SHOULD describe a concept descending from the Contributor Role Ontology.

--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -109,7 +109,7 @@ $defs:
       - type
 
   Activity:
-    inherits: gks.core:Entity
+    inherits: Entity
     maturity: draft
     description: >-
       An action or set of actions performed by an agent, that occurs over a period of time. Activities may use,
@@ -117,7 +117,7 @@ $defs:
     heritableProperties:
       subtype:
         type:
-          $refCurie: gks.core:Coding
+          $ref: "#/$defs/Coding"
         description: A more specific type of activity that an Activity object may represent.
       date:
         type: string
@@ -129,14 +129,14 @@ $defs:
         type: array
         ordered: false
         items:
-          $refCurie: gks.core:Agent
+          $ref: "#/$defs/Agent"
         description: >-
           An Agent who contributed to executing the Activity.
       specifiedBy:
         type: array
         ordered: false
         items:
-          $refCurie: gks.core:Method
+          $ref: "#/$defs/Method"
         description: >-
           A method that was followed in performing an Activity, that describes how it was executed.
 

--- a/schema/core-im/def/Activity.rst
+++ b/schema/core-im/def/Activity.rst
@@ -1,10 +1,10 @@
 **Computational Definition**
 
-An action taken by an agent in contributing to the creation, modification, assessment, or deprecation of a particular entity (e.g. a Statement, EvidenceLine, DataItem, Publication, etc.)
+An action or set of actions performed by an agent, that occurs over a period of time. Activities may use, generate, modify, move, or destroy one or more entities.
 
     **Information Model**
     
-Some Contribution attributes are inherited from :ref:`Activity`.
+Some Activity attributes are inherited from :ref:`Entity`.
 
     .. list-table::
        :class: clean-wrap
@@ -44,19 +44,11 @@ Some Contribution attributes are inherited from :ref:`Activity`.
           - string
           - 0..1
           - The date that the Activity was completed. The date SHOULD be formatted as a date string in ISO format "YYYY-MM-DD".
+       *  - performedBy
+          - :ref:`Agent`
+          - 0..m
+          - An Agent who contributed to executing the Activity.
        *  - specifiedBy
           - :ref:`Method`
           - 0..m
           - A method that was followed in performing an Activity, that describes how it was executed.
-       *  - type
-          - string
-          - 0..1
-          - MUST be "Contribution".
-       *  - contributor
-          - :ref:`Agent`
-          - 0..m
-          - The agent that made the contribution.
-       *  - activityType
-          - :ref:`Coding`
-          - 0..1
-          - SHOULD describe a concept descending from the Contributor Role Ontology.

--- a/schema/core-im/json/Contribution
+++ b/schema/core-im/json/Contribution
@@ -34,6 +34,25 @@
          },
          "description": "A list of extensions to the entity. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
       },
+      "subtype": {
+         "type": {
+            "$ref": "/ga4gh/schema/gks-core-im/1.x/json/Coding"
+         },
+         "description": "A more specific type of activity that an Activity object may represent."
+      },
+      "date": {
+         "type": "string",
+         "format": "date",
+         "description": "The date that the Activity was completed. The date SHOULD be formatted as a date string in ISO format \"YYYY-MM-DD\"."
+      },
+      "specifiedBy": {
+         "type": "array",
+         "ordered": false,
+         "items": {
+            "$ref": "/ga4gh/schema/gks-core-im/1.x/json/Method"
+         },
+         "description": "A method that was followed in performing an Activity, that describes how it was executed."
+      },
       "type": {
          "type": "string",
          "const": "Contribution",
@@ -41,26 +60,15 @@
          "description": "MUST be \"Contribution\"."
       },
       "contributor": {
-         "$ref": "/ga4gh/schema/gks-core-im/1.x/json/Agent",
-         "description": "The agent that made the contribution."
+         "type": "array",
+         "ordered": false,
+         "items": {
+            "$ref": "/ga4gh/schema/gks-core-im/1.x/json/Agent"
+         },
+         "description": "The agent that made the contribution.",
+         "$ref": "/ga4gh/schema/gks-core-im/1.x/json/Agent"
       },
-      "date": {
-         "type": "string",
-         "format": "date",
-         "description": "The date on which the contribution was made. The date SHOULD be formatted as a date string in ISO format \"YYYY-MM-DD\"."
-      },
-      "contributionMadeTo": {
-         "description": "The artifact toward which the contribution was made.",
-         "oneOf": [
-            {
-               "$ref": "/ga4gh/schema/gks-core-im/1.x/json/Document"
-            },
-            {
-               "$ref": "/ga4gh/schema/gks-core-im/1.x/json/Method"
-            }
-         ]
-      },
-      "activity": {
+      "activityType": {
          "$ref": "/ga4gh/schema/gks-core-im/1.x/json/Coding",
          "description": "SHOULD describe a concept descending from the Contributor Role Ontology."
       }


### PR DESCRIPTION
- Moved the Activity class from va-spec core-im into gkscommon (because Contribution inherits from this class). Made a couple minor updates to property descriptions here. 
- Updated Contribution to reference/extend Activity as needed 
    - state its inheritance from Activity 
    - define `contributor` to extend `performedBy`, so we can give a more precise definition and constrain cardinality to one Agent  
    - removed `contirbutionMadeTo` property - there is no real use case for it, as Contributions are always referenced from the artifacts contributed to, not the other way. And this avoids us needing to move InformationEntity into gks-common.
    - removed `date`, as this property is now inherited from Activity. 
    - changed name of `activity` -> `activityType`, to be clear that what goes here is a code representing the type of activity performed in making the contribution. For now, only one type allowed per contribution, but we may want to allow for an array here in the future.