### PR TITLE
Update Entity descriptions/comments in core-im-source.yaml

### DIFF
--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -51,7 +51,7 @@ $defs:
         description: >-
           A list of extensions to the Entity, that allow for capture of information not directly
           supported by elements defined in the model. 
-        comment >-
+        comment: >-
           Extension objects have a key-value data structure that allows definition of custom
           fields in the data itself. Extensions are not expected to be natively understood, 
           but may be used for pre-negotiated exchange of message attributes between systems.

--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -7,25 +7,36 @@ imports:
 
 $defs:
   Entity:
-    description: >-
-      Entity is the root class of the 'gks-common' core information model classes - those that
-      have identifiers and other general metadata like labels, xrefs, urls, descriptions, etc.
-      All common classes descend from and inherit its attributes.
+    description: Anything that exists, has existed, or will exist.
+    comment: >-
+      Entity is the root class of the 'gks-common' core information model. All common classes that
+      have ids and other general metadata like label, description, type, or extensions descend from
+      this class and inherit its attributes.
     heritableProperties:
       id:
         type: string
         description: >-
-          The 'logical' identifier of the entity in the system of record, e.g. a UUID. This 'id' is
-          unique within a given system. The identified entity may have a different 'id' in a different
-          system, or may refer to an 'id' for the shared concept in another system (e.g. a CURIE).
+          The 'logical' identifier of the Entity in the system of record, e.g. a UUID.  This 'id' is
+          unique within a given system, but may or may not be globally unique outside the system. It
+          is used within a system to reference an object from another.
+        comment: >-
+          Note that it is common for implementers to create their own internal logical ids - 
+          typically a serially or randomly generated value like a UUID that is assigned to the 
+          data object as it is created in a system. But an implementer may choose to re-use an 
+          existing, globally unique id from an external system or authority for this purpose 
+          (e.g. an HGNC id for a Gene object) - as long as it is unique within the implementing 
+          system, and can be used to reference the identified object in this context.
       type:
         type: string
+        description: >-
+          The name of the class that is instantiated by a data object representing the Entity.  
+        comment: MUST be the label of a concrete class from the data model. 
       label:
         type: string
         description: A primary name for the entity.
       description:
         type: string
-        description: A free-text description of the entity.
+        description: A free-text description of the Entity.
       alternativeLabels:
         type: array
         ordered: false
@@ -38,7 +49,11 @@ $defs:
         items:
           $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/Extension"
         description: >-
-          A list of extensions to the entity. Extensions are not expected to be natively understood,
+          A list of extensions to the Entity, that allow for capture of information not directly
+          supported by elements defined in the model. 
+        comment >-
+          Extension objects have a key-value data structure that allows definition of custom
+          fields in the data itself. Extensions are not expected to be natively understood, 
           but may be used for pre-negotiated exchange of message attributes between systems.
     heritableRequired:
       - type


### PR DESCRIPTION
Updated free-text descriptions / comments on some attributes in  the Entity class to be a bit more descriptive and/or provide some additional guidance on use - and to align with descriptions in the sepio model.