### PR TITLE
Update Method descriptions in core-im-source.yaml

### DIFF
--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -115,28 +115,34 @@ $defs:
     inherits: InformationEntity
     maturity: draft
     description: >-
-      A set of instructions that specify how to achieve some objective (e.g. experimental protocols,
-      curation guidelines, rule sets, etc.)
+      A set of instructions that specify how to achieve some objective. These may vary in the level
+      of detail they provide, and in scientific research, these include things like experimental 
+      protocols, study designs, data analysis parameters,  curation guidelines, cohort selection
+      criteria, and rule sets.
     properties:
       type:
         extends: type
         const: Method
         default: Method
         description: MUST be "Method".
-      isReportedIn:
-        oneOf:
-        - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/IRI"
-        - $ref: "#/$defs/Document"
       subtype:
         $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/Coding"
         description: >-
-          A more specific type of entity the method represents (e.g. Variant Interpretation Guideline,
-          Experimental Protocol)
+          A specific type of method that a Method instnace represents (e.g. 'Variant Interpretation
+          Guideline', or 'Experimental Protocol')
+        comments: >-
+          This attribute can be used to report a specific type for the Method, in cases where a model
+          does not define Method subclasses for this purpose.  Implementers can define their own set
+          of method type codes/terms, to match the needs of their application.
       license:
         type: string
         description: >-
-          A particular license that dictates legal permissions for how a published method (e.g. an
-          experimental protocol, workflow specification, curation guideline) can be used.
+          A specific license that dictates legal permissions for how a method can be used (by whom,
+          where, for what purposes, with what additional requirements, etc.)
+        comments: >-
+          Where possible, provide a URL pointing to the license or a description of it (e.g. 
+          "https://creativecommons.org/licenses/by/4.0/"). Otherwise, provide a free-text name or
+          description of the license (e.g. "CC-BY").
 
   Document:
     type: object

--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -128,7 +128,7 @@ $defs:
       subtype:
         $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/Coding"
         description: >-
-          A specific type of method that a Method instnace represents (e.g. 'Variant Interpretation
+          A specific type of method that a Method instance represents (e.g. 'Variant Interpretation
           Guideline', or 'Experimental Protocol')
         comments: >-
           This attribute can be used to report a specific type for the Method, in cases where a model


### PR DESCRIPTION
Updated free-text descriptions / comments on some attributes in  the Method class to be a bit more descriptive and/or provide some additional guidance on use - and to align with descriptions in the sepio model.

I also removed the `isReportedIn `attribute from Method, as this class now descends from InformationEntity and will inherit this attribute. 
