### PR TITLE
Various minor updates to core-im-source.yaml

### DIFF
--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -153,9 +153,7 @@ $defs:
           This attribute holds a structured RecordMetadata object, which can be used to capture when, how, and 
           by whom a record serialization was generated or modified; what upstream resources it was derived or retrieved 
           from; and record-level administrative information such as versioning and lifecycle status.
-    heritableRequired:
-      - id
-      - type
+
 
   Method:
     type: object
@@ -461,6 +459,7 @@ $defs:
           A quantitative score indicating the strength of support that an Evidence Line is determined to provide for or
           against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided
           value.
+          
   Statement:
     inherits: InformationEntity
     description: >-
@@ -523,11 +522,11 @@ $defs:
           Statements put forth a Proposition that expresses some possible fact about the world, and may provide an
           assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated
           evidence). The semantics of the Proposition are captured in the 'subject', 'predicate', 'object', and
-          optional 'qualifier' attributes. An assessment of the Proposition's validity can be captured using 
+          optional 'qualifier' attributes. An assessment of the Proposition's validity can be captured using
           'direction', 'strength', and 'score' attributes. The 'direction' attribute is used to indicate whether the
-          Statement's Proposition is *supported* by the agent's assessment (when evidence favors its validity), is 
+          Statement's Proposition is *supported* by the agent's assessment (when evidence favors its validity), is
           *disputed* by the agent's assessment (when evidence argues against its validity), or remains *neutral*
-          (when conflicting or insufficient evidence exists to assert one direction or the other). 
+          (when conflicting or insufficient evidence exists to assert one direction or the other).
           (Enumerated values = 'supports', 'disputes', 'neutral').
         type: string
         enum:
@@ -546,9 +545,9 @@ $defs:
           evidence). The semantics of the Proposition are captured in the 'subject,' 'predicate', 'object', and
           optional 'qualifier' attributes. An assessment of the Proposition's validity can be captured using 'direction',
           'strength', and 'score' attributes. The 'strength' attribute is used to report the strength of this
-          assessment in the direction indicated. Strength can be framed as a *level of confidence* that the Proposition  
+          assessment in the direction indicated. Strength can be framed as a *level of confidence* that the Proposition
           is true or false, or as a *level of evidence* that supports or disputes it. Data creators can define the
-          permissible values for the 'strength' attribute to indicate which of these facets is being assessed 
+          permissible values for the 'strength' attribute to indicate which of these facets is being assessed
           (e.g. 'high confidence' vs 'low confidence', or 'strong evidence' vs 'weak evidence') - or they can choose
           values that don't commit to one or the other if they don't want to make the distinction (e.g. 'high' vs
           'medium' vs 'low').

--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -56,6 +56,7 @@ $defs:
           fields in the data itself. Extensions are not expected to be natively understood, 
           but may be used for pre-negotiated exchange of message attributes between systems.
     heritableRequired:
+      - id
       - type
 
   DomainEntity:
@@ -219,11 +220,14 @@ $defs:
       title:
         type: string
         description: The official title given to the document by its authors.
-      url:
-        type: string
-        description: The URL/web address from which the content of the Document can be retrieved.
-        format: uri
-        pattern: "^(https?|s?ftp)://"
+      urls:
+        type: array
+        ordered: false
+        items:
+          type: string
+          format: uri
+          pattern: "^(https?|s?ftp)://"
+        description: One or more URLs from which the content of the Document can be retrieved.
       doi:
         type: string
         pattern: "^10.(\\d+)(\\.\\d+)*/[\\w\\-\\.]+"
@@ -518,13 +522,13 @@ $defs:
         comments: >-
           Statements put forth a Proposition that expresses some possible fact about the world, and may provide an
           assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated
-          evidence). The semantics of the Proposition are captured in the 'subject,' 'predicate', 'object', and
-          optional 'qualifier' attributes. The assessment of the Proposition's validity are captured in 'direction',
-          'strength', and 'score' attributes. The 'direction' attribute is used to indicate whether the Statement's
-          Proposition is supported by the agent's assessment  (when evidence favors its validity), is refuted by the
-          agent's assessment (when evidence argues against its validity), or remains neutral (when conflicting or
-          insufficient evidence exists to assert one direction or the other). (Enumerated values = 'supports',
-          'disputes', 'neutral').
+          evidence). The semantics of the Proposition are captured in the 'subject', 'predicate', 'object', and
+          optional 'qualifier' attributes. An assessment of the Proposition's validity can be captured using 
+          'direction', 'strength', and 'score' attributes. The 'direction' attribute is used to indicate whether the
+          Statement's Proposition is *supported* by the agent's assessment (when evidence favors its validity), is 
+          *disputed* by the agent's assessment (when evidence argues against its validity), or remains *neutral*
+          (when conflicting or insufficient evidence exists to assert one direction or the other). 
+          (Enumerated values = 'supports', 'disputes', 'neutral').
         type: string
         enum:
           - supports
@@ -540,14 +544,14 @@ $defs:
           Statements put forth a Proposition that expresses some possible fact about the world, and may provide
           an assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated
           evidence). The semantics of the Proposition are captured in the 'subject,' 'predicate', 'object', and
-          optional 'qualifier' attributes. The assessment of the Proposition's validity are captured in 'direction',
+          optional 'qualifier' attributes. An assessment of the Proposition's validity can be captured using 'direction',
           'strength', and 'score' attributes. The 'strength' attribute is used to report the strength of this
-          assessment in the direction indicated. Tee assessment can frame strength as a level of confidence that
-          the Proposition is true or false, or as a  level of evidence that supports or disputes it. Data creators
-          can define the permissible values for the 'strength' attribute to indicate which of these facets is being
-          assessed (e.g. 'high confidence' vs 'low confidence', or 'strong evidence' vs 'weak evidence') - or they
-          can chose values that don't commit to one or the other if they don't want to make the distinction (e.g.
-          'high' vs 'medium' vs 'low').
+          assessment in the direction indicated. Strength can be framed as a *level of confidence* that the Proposition  
+          is true or false, or as a *level of evidence* that supports or disputes it. Data creators can define the
+          permissible values for the 'strength' attribute to indicate which of these facets is being assessed 
+          (e.g. 'high confidence' vs 'low confidence', or 'strong evidence' vs 'weak evidence') - or they can choose
+          values that don't commit to one or the other if they don't want to make the distinction (e.g. 'high' vs
+          'medium' vs 'low').
         oneOf:
           - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/Coding"
           - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/IRI"          
@@ -561,7 +565,7 @@ $defs:
         comments: >-
           Statements put forth a Proposition that expresses some possible fact about the world, and may provide an
           assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated
-          evidence). The semantics of the Proposition are captured in the 'subject,' 'predicate', 'object', and optional
+          evidence). The semantics of the Proposition are captured in the 'subject', 'predicate', 'object', and optional
           'qualifier' attributes. The assessment of the Proposition's validity are captured in 'direction', 'strength',
           and 'score' attributes.  The 'score' attribute serves the same purpose as 'strength', but allows for a
           quantitative assessment based on a numerical score.
@@ -622,7 +626,8 @@ $defs:
           proposition. Evidence Lines can be omitted if such information is not available or needed. 
     heritableRequired:
       - subject
-      - direction
+      - predicate
+      - object
 
   DataSet:
     inherits: InformationEntity
@@ -847,7 +852,7 @@ $defs:
   #       const: Proposition
   #       default: Proposition
   #       description: Must be "Proposition"
-  #     statementText:
+  #     propositionText:
   #       type: string
   #       description: >-
   #        A natural-language expression of the Proposition's meaning. e.g. "BRCA2 c.8023A>G is pathogenic for


### PR DESCRIPTION
Putting various small changes together in one PR - can split out if needed.

- minor fixes to comments in a couple Statement attributes

- changed name of commented out Proposition.statemetText property to 'propositionText' 

- made id required in Entity (seems like an oversight but maybe there's something I am not considering?)

- made predicate and object required in the Statement class (at present only subject is required, but I think all should be required, and indeed the SPO attributes extending them in all Statement Profiles created in the va spec repo are required. 

- removed 'direction' from required attributes in Statement - in the core-im, I think we want to allow for population of just the SPO under the paradigm where data creators simply want to use Statements to express things they believe to be true about the domain.  Indeed, many of the standard profiles already defined do not include/require a `direction` attribute - and thus would be in violation if it was required in the core-im. We can always make direction required in specific statement profiles if we want, or implementers can do this in implementation models - but we should not do so in the core-im - which we want to be less restrictive to support broad use cases.

- gave the Dcoument.url attribute a plural label and made it multivalued (as we should be able to capture multiple urls for a document). Updated description accordingly.