### PR TITLE
Corrected 'comments' field name in core-im-source.yaml

### DIFF
--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -273,7 +273,7 @@ $defs:
           $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/Coding"
         description: >-
           A specific type of activity the Activity instance represents.
-        comments: >-
+        $comment: >-
           This attribute can be used to report a specific type for the Activity, in cases where 
           a model does not define Activity subclasses for this purpose. Implementers can define 
           their own set of data set type codes/terms, to match the needs of the domain or application.           
@@ -320,7 +320,7 @@ $defs:
         maxItems: 1
         description: >-
           The agent that made the contribution.
-        comments: >-
+        $comment: >-
           Note that this must be a single agent (which can be a Person, or an Organization).
           If multiple Agents contributed to an entity, a separate Contribution instances MUST be
           created for each. 
@@ -381,7 +381,7 @@ $defs:
       An independent, evidence-based argument that may support or refute the validity of a specific proposition.
       The strength and direction of this argument is based on an interpretation of one or more pieces of
       information as evidence for or against the target proposition.
-    comments: >-
+    $comment: >-
       Evidence Lines are used to capture various pieces of information (i.e. 'evidence items') that are
       assessed together as an argument for or against some 'target proposition' - to report the direction
       (supports or disputes) and strength (e.g. strong, moderate, weak) that the argument is determined to
@@ -424,7 +424,7 @@ $defs:
         description: >-
           An individual piece of information that was evaluated as evidence in building the argument represented
           by an Evidence Line.
-        comments: >-
+        $comment: >-
           A given Evidence Line may be supported by one or many individual evidence items. What matters is that all
           evidence items in a given Evidence Line get collectively assessed and assigned direction and strength as
           a single argument for or against a target proposition. 
@@ -447,7 +447,7 @@ $defs:
         description: >-
           The strength of support that an Evidence Line is determined to provide for or against its target Proposition, 
           evaluated relative to the direction indicated by the directionOfEvidenceProvided value. 
-        comments: >-
+        $comment: >-
           Values of this attribute can be defined by for a given profile based on domain/application needs, but should
           be framed in qualitative terms (e.g. 'strong', 'moderate', 'weak'). The 'scoreOfEvidenceProvided' attribute
           can be used to report quantitative assessments of evidence provided.          
@@ -463,13 +463,13 @@ $defs:
       A claim of purported truth as made by a particular agent, on a particular occasion. Statements may be used 
       to simply put forth a possible fact (i.e. a 'proposition') as true, or to provide a more nuanced assessment
       of the level of confidence or evidence supporting a particular proposition. 
-    comments: >-
+    $comment: >-
       In the SEPIO model, primary assertions of knowledge about some subject entity is captured in self-contained Statement
       objects. Organization of assertions into discrete Statement objects allows clear and precise tracking of the evidence
       and provenance that supports each. Statement semantics are explicitly captured using 'subject', 'predicate', and
       'object' attributes, and optional 'qualifier' slot(s). This 'SPOQ' pattern is used to structure the meaning of the
       Statement's "proposition" - the 'possible fact' it assesses or reports to be true.
-    comments: >-      
+    $comment: >-      
       SEPIO supports two "modes of use" for Statements, which differ in what they say about their SPOQ proposition, and
       can be distinguished by whether 'direction' and 'strength' attributes are populated. 
       
@@ -488,7 +488,7 @@ $defs:
         oneOf:
         - type: object
         description: The Entity about which the Statement is made.
-        comments: >-
+        $comment: >-
           While the Core Information Model is domain-agnostic, and supports Statements about any type of
           Entity, for most VA-Spec implementations the subject will be a some type of genetic or molecular
           variation. But data creators may want to make statements about other entities or concepts that
@@ -497,7 +497,7 @@ $defs:
       predicate:
         type: string
         description: The relationship declared to hold between the subject and the object of the Statement.
-        comments: >-
+        $comment: >-
           When applied to represent a particular type of Statement (via 'Profiling'), implementers can define a value
           set of predicates for the relationships relevant in the domain - ideally using terms from community ontologies
           or terminologies. For example, in a  'Variant Pathogenicity Statement' Profile, the predicate value set might
@@ -507,7 +507,7 @@ $defs:
         oneOf:
         - type: object
         description: An Entity or concept that is related to the subject of a Statement via its predicate.
-        comments: >-
+        $comment: >-
           The object of a Statement can be any Entity or concept that is related to the subject, e.g. for Genetic
           Variation subjects this is often a disease, drug, gene, molecular consequence, functional impact on
           gene or protein.
@@ -515,7 +515,7 @@ $defs:
         description: >-
           A term indicating whether the Statement supports, disputes, or remains neutral w.r.t. the validity of the
           Proposition it evaluates. 
-        comments: >-
+        $comment: >-
           Statements put forth a Proposition that expresses some possible fact about the world, and may provide an
           assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated
           evidence). The semantics of the Proposition are captured in the 'subject,' 'predicate', 'object', and
@@ -536,7 +536,7 @@ $defs:
           strongly supported or disputed the Proposition is believed to be).  Depending on its implementation,
           a strength assessment may be framed in terms of how *confident* the agent is that the Proposition is
           true or false, or in terms of the *strength of evidence* they believe supports or disputes it.
-        comments: >-
+        $comment: >-
           Statements put forth a Proposition that expresses some possible fact about the world, and may provide
           an assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated
           evidence). The semantics of the Proposition are captured in the 'subject,' 'predicate', 'object', and
@@ -558,7 +558,7 @@ $defs:
           (i.e. how strongly supported or disputed the Proposition is believed to be).  Depending on its implementation,
           a score may reflect how *confident* that agent is that the Proposition is true or false, or the *strength of
           evidence* they believe supports or disputes it.
-        comments: >-
+        $comment: >-
           Statements put forth a Proposition that expresses some possible fact about the world, and may provide an
           assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated
           evidence). The semantics of the Proposition are captured in the 'subject,' 'predicate', 'object', and optional
@@ -568,7 +568,7 @@ $defs:
       statementText:
         type: string
         description: A natural-language expression of what a Statement asserts to be true.
-        comments: >-
+        $comment: >-
           This attribute captures what a Statement says as human readable free text. e.g. that
           "BRCA2 c.8023A>G is pathogenic for Breast Cancer", or that "there is moderate evidence
           supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer". This optional attribute 
@@ -592,7 +592,7 @@ $defs:
           A single term or phrase summarizing the outcome of direction and strength
           assessments of a Statement's proposition, in terms of a classification of 
           its subject.
-        comments: >-
+        $comment: >-
           Permissible values for this attribute are  typically selected to be succinct and familiar in
           the target community of practice - and can be provided to report of a statement's conclusion
           in user-friendly terms. For example, in a Statement assessing the proposition that
@@ -609,7 +609,7 @@ $defs:
           Statement assesses or puts forth as true. The strength and direction of this argument (whether
           it supports or disputes the proposition, and how strongly) is based on an interpretation
           of one or more pieces of information as evidence (i.e. 'Evidence Items).
-        comments: >-
+        $comment: >-
           Evidence Lines result from the interpretation of one or more pieces of information to build an
           argument for or against a particular Proposition. These arguments have direction (supporting /
           disputing) and strength (e.g. strong, moderate, weak) relative to the Proposition they are
@@ -631,7 +631,7 @@ $defs:
     description: >-
       A collection of related data items or records that are organized together in a common format
       or structure, to enable their computational manipulation as a unit.
-    comments: >-
+    $comment: >-
       Instances of this class represent a specific version of a given dataset. Examples include the
       gnomAD version 3.1.2 dataset carrying allele population frequencies, or a specific version of
       a VCF file that describes variations observed in a particular patient and various annotations
@@ -649,7 +649,7 @@ $defs:
           A specific type of data set the DataSet instance represents (e.g. a
           'clinical data set', a 'sequencing data set', a 'gene expression data set',
           a 'genome annotation data set')
-        comments: >-
+        $comment: >-
           This attribute can be used to report a specific type for the DataSet,
           in cases where a model does not define DataSet subclasses for this purpose.
           Implementers can define their own set of data set type codes/terms, to match
@@ -658,14 +658,14 @@ $defs:
         type: string
         format: datetime
         description: Indicates when a version of a Data Set was formally released.
-        comments: >-
+        $comment: >-
           This attribute may apply to version and distribution-level DataSet representations.
           It refers to when the data set was released, which may be different than the data set
           was generated.
       version:
         type: string
         description: The version of the Data Set, as assigned by its creator.
-        comments: >-
+        $comment: >-
           This property can capture version information for resources such as data sets and documents
           that get published and released as a unit for community use. These may go through rounds of
           revisions that add or modify content, but don’t change the identity of the resource. Use this
@@ -675,7 +675,7 @@ $defs:
         description: >-
           A specific license that dictates legal permissions for how a data set can be used
           (by whom, where, for what purposes, with what additional requirements, etc.)
-        comments: >-
+        $comment: >-
           Where possible, provide a URL pointing to the license or a description of it
           (e.g. "https://creativecommons.org/licenses/by/4.0/"). Otherwise, provide a free-text name or
           description of the license (e.g. "CC-BY").
@@ -687,7 +687,7 @@ $defs:
       A collection of data items from a single study that pertain to a particular subject or
       experimental unit in the study, along with optional provenance information describing
       how these data items were generated.
-    comments: >-
+    $comment: >-
       StudyResults provide a useful way to capture a subset of items from a study dataset that
       are used as evidence in generating higher order knowledge assertions about the entity that
       is the focus of the study result. For example, a subset of allele frequency data items
@@ -703,7 +703,7 @@ $defs:
         description: >-
           The specific subject or experimental unit in a Study that data in the StudyResult object is about -
           e.g. a particular variant in a population allele frequency dataset like ExAC or gnomAD.
-      comments: >-        
+      $comment: >-        
         The 'focus' of a StudyResult is the what anchors selection of all data items and provenance
         information that it contains. This focus may be a single participant or subject of a study
         (e.g. one patient in a clinical study, or one allele in a population frequency analysis).
@@ -718,7 +718,7 @@ $defs:
         maximum: 1
         description: >-
           A larger DataSet from which the content of the StudyResult was derived.
-        comments: >-
+        $comment: >-
           In most cases, a StudyResult will be generated using data from one source dataset - but it is
           possible multiple datasets related to a single study contain data about a particular focus that
           get collected into a single StudyResult instance.
@@ -731,7 +731,7 @@ $defs:
           Another StudyResult comprised of data items about the same focus as its parent Result, but based on a more narrowly
           scoped analysis of the foundational data (e.g. an analysis based on data about a subset of the parent Results
           full study population) .
-        comments: >-
+        $comment: >-
           This attribute allows data creators to break down a StudyResult into finer-grained StudyResult instances with a
           narrower scope. For example, a StudyResult about the frequency of an allele in a global population of individuals
           can be broken down into separate 'component' Results about distinct subpopulations of individuals in the source data
@@ -741,7 +741,7 @@ $defs:
         description: >-
           A description of a specific group or population of subjects interrogated in the ResearchStudy that produced the
           data captured in the StudyResult.
-        comments: >-
+        $comment: >-
           For example, in a StudyResult holding allele frequency data, this attribute points to a StudyGroup object that
           describes characteristics of the population that the frequency data was generated from (e.g. 'East Asian', 'Female').  
       ancillaryResults:
@@ -764,7 +764,7 @@ $defs:
       scientific study based on their exhibiting one or more common characteristics  (e.g. species, race,
       age, gender, disease state, income) May be referred to as a 'cohort' or 'population' in specific
       research settings.
-    comments: >-
+    $comment: >-
       A Study Group may include all participants in a given study, or specific subsets that are designated
       based on shared roles or characteristics.
     properties:
@@ -797,7 +797,7 @@ $defs:
     description: >-
       An object holding a name-value pair used to describe a trait or role of an individual
       member of a StudyGroup.
-    comments: >-
+    $comment: >-
       This flexible key-value like object is where specific inclusion or exclusion criteria for
       membership in a StudyGroup are formally defined. It should be used to capture characteristics
       that inhere in individual members of the StudyGroup (e.g. inherent traits like their sex, race,
@@ -818,7 +818,7 @@ $defs:
         description: >-
           An operation that defines how to logically interpret a set of more than one Characteristic
           values ('AND', 'OR', 'NOT')
-        comments: >-
+        $comment: >-
           An 'AND' operator indicates that an individual exhibits all of the characteristic values listed.
           An 'OR' operator indicates the individual exhibits one or more of the characteristic values listed.
           A 'NOT' indicates that the individual does not exhibit the characteristic value or values listed. 


### PR DESCRIPTION
Fixed name of 'comments:' field to '$comment:', to be consistent with Alex's earlier update.