### PR TITLE
change `subjectClassificaiton` back to `classification` in the core-im-source.yaml

### DIFF
--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -617,7 +617,7 @@ $defs:
       #     This attribute supports an alternate modeling pattern, which encapsulates the structured semantics of
       #     the possible fact asserted or evaluated by a Statement in a separate 'Proposition' object - instead of
       #     using the 'subject', 'predicate', 'object', and 'qualifier' properties defined in the Statement object itself.
-      subjectClassification:
+      classification:
         oneOf:
           - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/Coding"
           - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/IRI"


### PR DESCRIPTION
Proposing to change `subjectClassification` back to `classification` (despite being the one who suggested the `subjectClassificaiton` in the first place.  This is because in the context of Statement profiles like the VariantPathogenicityStatement profile here, we app;y the pattern of renaming the core-im `subject` property by appending the type of thing the subject is - e,g. `subjectVariant` .  It is therefore confusing to see an attribute called `subjectClassification`, as it implies that a Classification is the subject of the statement.  

Lets go back to the simpler name `classification`, and leave it to the attribute description to tell users that this is a classification of the entity representing the Statement's subject. 

Shoudln't be too controversial as I think this is what LaArry and Alex had called this attribute originally.