### PR TITLE
Update core-im-source.yaml to support Functional Impact profiles

### DIFF
--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -408,16 +408,13 @@ $defs:
         const: EvidenceLine
         default: EvidenceLine
         description: Must be "EvidenceLine"
-      # Note that the `targetProposition` property below is a proposed addition to the EvidenceLine class that is not
-      # yet implemented in the core IM - but included as below to help clarify the meaning and utility of this class.
-      #
-      # targetProposition:
-      #   $ref: "#/$defs/Proposition"
-      #   description: >-
-      #     The possible fact against which evidence items contained in an Evidence Line were collectively evaluated,
-      #     in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based
-      #     assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against
-      #     a target proposition that the variant is pathogenic for a specific disease.
+      targetProposition:
+        $ref: "#/$defs/Proposition"
+        description: >-
+          The possible fact against which evidence items contained in an Evidence Line were collectively evaluated,
+          in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based
+          assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against
+          a target proposition that the variant is pathogenic for a specific disease.
       hasEvidenceItems:
         type: array
         ordered: false
@@ -446,6 +443,7 @@ $defs:
         oneOf:
           - $ref: "#/$defs/Coding"
           - $ref: "#/$defs/IRI"
+          - string                          # This is likely not the right way to specify that a string value is allowed for this attribute . . . . please fix
         description: >-
           The strength of support that an Evidence Line is determined to provide for or against its target Proposition,
           evaluated relative to the direction indicated by the directionOfEvidenceProvided value.
@@ -503,10 +501,7 @@ $defs:
         description: The relationship declared to hold between the subject and the object of the Statement.
         $comment: >-
           When applied to represent a particular type of Statement (via 'Profiling'), implementers can define a value
-          set of predicates for the relationships relevant in the domain - ideally using terms from community ontologies
-          or terminologies. For example, in a  'Variant Pathogenicity Statement' Profile, the predicate value set might
-          include terms from the GENO ontology defining  'pathogenic for condition', 'benign for condition', and
-          'uncertain significance for condition' relationships (GENO:0000840, GENO:0000843, GENO:0000845).
+          set of predicates for the relationships relevant in the domain.
       object:
         oneOf:
         - type: object
@@ -619,6 +614,7 @@ $defs:
         oneOf:
           - $ref: "#/$defs/Coding"
           - $ref: "#/$defs/IRI"
+          - string                                # This is likely not the right way to specify that a string value is allowed for this attribute . . . . please fix
         description: >-
           A single term or phrase summarizing the outcome of direction and strength
           assessments of a Statement's proposition, in terms of a classification of
@@ -880,54 +876,50 @@ $defs:
       - name
       - value
 
-
-  # Note that the `Proposition` class below is a proposed addition to the model that would be used by both the Statement
-  # and EvidenceLine classes, but is not yet implemented in the core IM. See the commented out attributes on these classes for more info.
-  #
-  # Proposition:
-  #   inherits: Entity
-  #   maturity: draft
-  #   type: object
-  #   description: >-
-  #     The abstract entity representing a possible fact that may be put forth as true, or subjected to
-  #     an evidence-based assessment, by a Statement. As abstract entities, their identity and existence
-  #     are independent of space and time, and whether they are ever asserted to be true by some agent.
-  #     Propositions may be used in two contexts; (1) by Statements that assert them to be true or false,
-  #     or describe the overall level of confidence/evidence for or against them; (2) by Evidence Lines that
-  #     report the direction and strength of an evidence-based argument for the Proposition.
-  #   properties:
-  #     type:
-  #       extends: type
-  #       const: Proposition
-  #       default: Proposition
-  #       description: Must be "Proposition"
-  #     propositionText:
-  #       type: string
-  #       description: >-
-  #        A natural-language expression of the Proposition's meaning. e.g. "BRCA2 c.8023A>G is pathogenic for
-  #        Breast Cancer".
-  #     subject:
-  #       type:
-  #         $ref: "#/$defs/Entity"
-  #       description: The Entity or concept about which the Proposition is made.
-  #     predicate:
-  #       type:
-  #         $ref: "#/$defs/Coding"
-  #       description: The relationship asserted to hold between the subject and the object of the Proposition.
-  #     object:
-  #       type:
-  #         $ref: "#/$defs/Entity"
-  #       description: An Entity that is related to the subject of a Proposition via its predicate.
-  #     negated:
-  #       type: boolean
-  #       description: >-
-  #         A boolean flag set to 'true' to represent a negation of the proposition expressed by the subject, predicate,
-  #         object, and qualifiers (e.g. that "Variant X is NOT pathogenic for Disease Y")/
-  #   heritableRequired:
-  #     - subject
-  #     - predicate
-  #     - object
-
+  Proposition:
+    inherits: Entity
+    maturity: draft
+    type: object
+    description: >-
+      The abstract entity representing a possible fact that may be put forth as true, or subjected to
+      an evidence-based assessment, by a Statement. As abstract entities, their identity and existence
+      are independent of space and time, and whether they are ever asserted to be true by some agent.
+      Propositions may be used in two contexts; (1) by Statements that assert them to be true or false,
+      or describe the overall level of confidence/evidence for or against them; (2) by Evidence Lines that
+      report the direction and strength of an evidence-based argument for the Proposition.
+    heritableProperties:
+      type:
+        extends: type
+        const: Proposition
+        default: Proposition
+        description: Must be "Proposition"
+      propositionText:
+        type: string
+        description: >-
+         A natural-language expression of the Proposition's meaning. e.g. "BRCA2 c.8023A>G is pathogenic for
+         Breast Cancer".
+      subject:
+        oneOf:
+        - type: object
+        description: The Entity or concept about which the Proposition is made.
+      predicate:
+        type: string
+        description: The relationship declared to hold between the subject and the object of the Statement.
+        $comment: >-
+          When applied to represent a particular type of Proposition (via 'Profiling'), implementers can define a value
+          set of predicates for the relationships relevant in the domain.
+      object:
+        oneOf:
+        - type: object
+        description: An Entity or concept that is related to the subject of a Proposition via its predicate.
+        $comment: >-
+          The object of a Proposition can be any Entity or concept that is related to the subject, e.g. for Genetic
+          Variation subjects the object is often a disease, drug, gene, molecular consequence, functional impact on
+          gene or protein.      
+    heritableRequired:
+      - subject
+      - predicate
+      - object
 
   Coding:
     type: object

--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -169,7 +169,7 @@ $defs:
         default: Method
         description: MUST be "Method".
       subtype:
-        $ref: "#/$defs/Coding"
+        $ref: "#/$defs/MappableConcept"
         description: >-
           A specific type of method that a Method instance represents (e.g. 'Variant Interpretation
           Guideline', or 'Experimental Protocol').
@@ -205,7 +205,7 @@ $defs:
         default: Document
         description: Must be "Document"
       subtype:
-        $ref: "#/$defs/Coding"
+        $ref: "#/$defs/MappableConcept"
         description: >-
           A specific type of document that a Document instance represents (e.g.  'publication',
           'patent', 'pathology report')
@@ -271,7 +271,7 @@ $defs:
       Activities may use, generate, modify, move, or destroy one or more entities.
     heritableProperties:
       subtype:
-        $ref: "#/$defs/Coding"
+        $ref: "#/$defs/MappableConcept"
         description: >-
           A specific type of activity the Activity instance represents.
         $comment: >-
@@ -326,7 +326,7 @@ $defs:
           If multiple Agents contributed to an entity, a separate Contribution instances MUST be
           created for each.
       activityType:
-        $ref: "#/$defs/Coding"
+        $ref: "#/$defs/MappableConcept"
         description: >-
           The specific type of activity performed or role played by an agent in making the contribution
           (e.g. for a publication, agents may contribute as a primary author, editor, figure designer,
@@ -441,10 +441,7 @@ $defs:
           The direction of support that the Evidence Line is determined to provide toward its target Proposition
           (supports, disputes, neutral)
       strengthOfEvidenceProvided:
-        oneOf:
-          - $ref: "#/$defs/Coding"
-          - $ref: "#/$defs/IRI"
-          - string                          # This is likely not the right way to specify that a string value is allowed for this attribute . . . . please fix
+        $ref: "#/$defs/MappableConcept"
         description: >-
           The strength of support that an Evidence Line is determined to provide for or against its target Proposition,
           evaluated relative to the direction indicated by the directionOfEvidenceProvided value.
@@ -573,9 +570,7 @@ $defs:
           (e.g. 'high confidence' vs 'low confidence', or 'strong evidence' vs 'weak evidence') - or they can choose
           values that don't commit to one or the other if they don't want to make the distinction (e.g. 'high' vs
           'medium' vs 'low').
-        oneOf:
-          - $ref: "#/$defs/Coding"
-          - $ref: "#/$defs/IRI"
+        $ref: "#/$defs/MappableConcept"
       score:
         type: number
         description: >-
@@ -612,10 +607,7 @@ $defs:
       #     the possible fact asserted or evaluated by a Statement in a separate 'Proposition' object - instead of
       #     using the 'subject', 'predicate', 'object', and 'qualifier' properties defined in the Statement object itself.
       classification:
-        oneOf:
-          - $ref: "#/$defs/Coding"
-          - $ref: "#/$defs/IRI"
-          - string                                # This is likely not the right way to specify that a string value is allowed for this attribute . . . . please fix
+        $ref: "#/$defs/MappableConcept"
         description: >-
           A single term or phrase summarizing the outcome of direction and strength
           assessments of a Statement's proposition, in terms of a classification of
@@ -673,7 +665,7 @@ $defs:
         default: DataSet
         description: MUST be "DataSet".
       subtype:
-        $ref: "#/$defs/Coding"
+        $ref: "#/$defs/MappableConcept"
         description: >-
           A specific type of data set the DataSet instance represents (e.g. a
           'clinical data set', a 'sequencing data set', a 'gene expression data set',
@@ -726,8 +718,8 @@ $defs:
     heritableProperties:
       focus:
         oneOf:
-          - $ref: "#/$defs/DomainEntity"
-          - $ref: "#/$defs/Coding"
+          - $ref: "#/$defs/Entity"
+          - $ref: "#/$defs/MappableConcept"
           - $ref: "#/$defs/IRI"
         description: >-
           The specific subject or experimental unit in a Study that data in the StudyResult object is about -

--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -873,7 +873,6 @@ $defs:
   Proposition:
     inherits: Entity
     maturity: draft
-    type: object
     description: >-
       The abstract entity representing a possible fact that may be put forth as true, or subjected to
       an evidence-based assessment, by a Statement. As abstract entities, their identity and existence

--- a/schema/core-im/def/Activity.rst
+++ b/schema/core-im/def/Activity.rst
@@ -41,7 +41,7 @@ Some Activity attributes are inherited from :ref:`Entity`.
       - 0..m
       - A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.
    *  - subtype
-      - :ref:`Coding`
+      - :ref:`MappableConcept`
       - 0..1
       - A specific type of activity the Activity instance represents.
    *  - date

--- a/schema/core-im/def/Contribution.rst
+++ b/schema/core-im/def/Contribution.rst
@@ -37,7 +37,7 @@ Some Contribution attributes are inherited from :ref:`Activity`.
       - 0..m
       - A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.
    *  - subtype
-      - :ref:`Coding`
+      - :ref:`MappableConcept`
       - 0..1
       - A specific type of activity the Activity instance represents.
    *  - date
@@ -57,6 +57,6 @@ Some Contribution attributes are inherited from :ref:`Activity`.
       - 1..1
       - The agent that made the contribution.
    *  - activityType
-      - :ref:`Coding`
+      - :ref:`MappableConcept`
       - 0..1
       - The specific type of activity performed or role played by an agent in making the contribution (e.g. for a publication, agents may contribute as a primary author, editor, figure designer, data generator, etc. . Values of this property may be framed as activities or as contribution roles (e.g. using terms from the Contribution Role Ontology (CRO)).

--- a/schema/core-im/def/DataSet.rst
+++ b/schema/core-im/def/DataSet.rst
@@ -65,7 +65,7 @@ Some DataSet attributes are inherited from :ref:`InformationEntity`.
       - 1..1
       - MUST be "DataSet".
    *  - subtype
-      - :ref:`Coding`
+      - :ref:`MappableConcept`
       - 0..1
       - A specific type of data set the DataSet instance represents (e.g. a 'clinical data set', a 'sequencing data set', a 'gene expression data set', a 'genome annotation data set')
    *  - releaseDate

--- a/schema/core-im/def/Document.rst
+++ b/schema/core-im/def/Document.rst
@@ -65,7 +65,7 @@ Some Document attributes are inherited from :ref:`InformationEntity`.
       - 1..1
       - Must be "Document"
    *  - subtype
-      - :ref:`Coding`
+      - :ref:`MappableConcept`
       - 0..1
       - A specific type of document that a Document instance represents (e.g.  'publication', 'patent', 'pathology report')
    *  - title

--- a/schema/core-im/def/EvidenceLine.rst
+++ b/schema/core-im/def/EvidenceLine.rst
@@ -64,6 +64,10 @@ Some EvidenceLine attributes are inherited from :ref:`InformationEntity`.
       - string
       - 1..1
       - Must be "EvidenceLine"
+   *  - targetProposition
+      - :ref:`Proposition`
+      - 0..1
+      - The possible fact against which evidence items contained in an Evidence Line were collectively evaluated, in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against a target proposition that the variant is pathogenic for a specific disease.
    *  - hasEvidenceItems
       - :ref:`InformationEntity`
       - 0..m
@@ -73,7 +77,7 @@ Some EvidenceLine attributes are inherited from :ref:`InformationEntity`.
       - 0..1
       - The direction of support that the Evidence Line is determined to provide toward its target Proposition (supports, disputes, neutral)
    *  - strengthOfEvidenceProvided
-      - :ref:`Coding` | :ref:`IRI`
+      - :ref:`MappableConcept`
       - 0..1
       - The strength of support that an Evidence Line is determined to provide for or against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided value.
    *  - scoreOfEvidenceProvided

--- a/schema/core-im/def/Method.rst
+++ b/schema/core-im/def/Method.rst
@@ -65,7 +65,7 @@ Some Method attributes are inherited from :ref:`InformationEntity`.
       - 1..1
       - MUST be "Method".
    *  - subtype
-      - :ref:`Coding`
+      - :ref:`MappableConcept`
       - 0..1
       - A specific type of method that a Method instance represents (e.g. 'Variant Interpretation Guideline', or 'Experimental Protocol').
    *  - license

--- a/schema/core-im/def/Proposition.rst
+++ b/schema/core-im/def/Proposition.rst
@@ -1,0 +1,58 @@
+**Computational Definition**
+
+The abstract entity representing a possible fact that may be put forth as true, or subjected to an evidence-based assessment, by a Statement. As abstract entities, their identity and existence are independent of space and time, and whether they are ever asserted to be true by some agent. Propositions may be used in two contexts; (1) by Statements that assert them to be true or false, or describe the overall level of confidence/evidence for or against them; (2) by Evidence Lines that report the direction and strength of an evidence-based argument for the Proposition.
+
+**Information Model**
+
+Some Proposition attributes are inherited from :ref:`Entity`.
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Type
+      - Limits
+      - Description
+   *  - id
+      - string
+      - 0..1
+      - The 'logical' identifier of the Entity in the system of record, e.g. a UUID.  This 'id' is unique within a given system, but may or may not be globally unique outside the system. It is used within a system to reference an object from another.
+   *  - label
+      - string
+      - 0..1
+      - A primary name for the entity.
+   *  - description
+      - string
+      - 0..1
+      - A free-text description of the Entity.
+   *  - alternativeLabels
+      - string
+      - 0..m
+      - Alternative name(s) for the Entity.
+   *  - extensions
+      - :ref:`Extension`
+      - 0..m
+      - A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.
+   *  - type
+      - string
+      - 1..1
+      - Must be "Proposition"
+   *  - propositionText
+      - string
+      - 0..1
+      - A natural-language expression of the Proposition's meaning. e.g. "BRCA2 c.8023A>G is pathogenic for Breast Cancer".
+   *  - subject
+      - object
+      - 1..1
+      - The Entity or concept about which the Proposition is made.
+   *  - predicate
+      - string
+      - 1..1
+      - The relationship declared to hold between the subject and the object of the Statement.
+   *  - object
+      - object
+      - 1..1
+      - An Entity or concept that is related to the subject of a Proposition via its predicate.

--- a/schema/core-im/def/Statement.rst
+++ b/schema/core-im/def/Statement.rst
@@ -81,7 +81,7 @@ Some Statement attributes are inherited from :ref:`InformationEntity`.
       - 0..1
       - A term indicating whether the Statement supports, disputes, or remains neutral w.r.t. the validity of the Proposition it evaluates.
    *  - strength
-      - :ref:`Coding` | :ref:`IRI`
+      - :ref:`MappableConcept`
       - 0..1
       - A term used to report the strength of a Proposition's assessment in the direction indicated (i.e. how strongly supported or disputed the Proposition is believed to be).  Implementers may choose to frame a strength assessment in terms of how *confident* an agent is that the Proposition is true or false, or in terms of the *strength of all evidence* they believe supports or disputes it.
    *  - score
@@ -93,7 +93,7 @@ Some Statement attributes are inherited from :ref:`InformationEntity`.
       - 0..1
       - A natural-language expression of what a Statement asserts to be true.
    *  - classification
-      - :ref:`Coding` | :ref:`IRI`
+      - :ref:`MappableConcept`
       - 0..1
       - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of its subject.
    *  - hasEvidenceLines

--- a/schema/core-im/def/StudyResult.rst
+++ b/schema/core-im/def/StudyResult.rst
@@ -61,7 +61,7 @@ Some StudyResult attributes are inherited from :ref:`InformationEntity`.
       - 0..1
       - Provenance metadata about a specific concrete record of information as encoded/serialized in a particular data set or object (as opposed to provenance about the abstract information content the encoding carries).
    *  - focus
-      - :ref:`DomainEntity` | :ref:`Coding` | :ref:`IRI`
+      - :ref:`Entity` | :ref:`MappableConcept` | :ref:`IRI`
       - 0..1
       - The specific subject or experimental unit in a Study that data in the StudyResult object is about - e.g. a particular variant in a population allele frequency dataset like ExAC or gnomAD.
    *  - sourceDataSet

--- a/schema/core-im/json/Contribution
+++ b/schema/core-im/json/Contribution
@@ -37,7 +37,7 @@
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
       },
       "subtype": {
-         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/Coding",
+         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/MappableConcept",
          "description": "A specific type of activity the Activity instance represents.",
          "$comment": "This attribute can be used to report a specific type for the Activity, in cases where a model does not define Activity subclasses for this purpose. Implementers can define their own set of data set type codes/terms, to match the needs of the domain or application."
       },
@@ -74,7 +74,7 @@
          "$comment": "Note that this must be a single agent (which can be a Person, or an Organization). If multiple Agents contributed to an entity, a separate Contribution instances MUST be created for each."
       },
       "activityType": {
-         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/Coding",
+         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/MappableConcept",
          "description": "The specific type of activity performed or role played by an agent in making the contribution (e.g. for a publication, agents may contribute as a primary author, editor, figure designer, data generator, etc. . Values of this property may be framed as activities or as contribution roles (e.g. using terms from the Contribution Role Ontology (CRO))."
       }
    },

--- a/schema/core-im/json/DataSet
+++ b/schema/core-im/json/DataSet
@@ -118,7 +118,7 @@
          "description": "MUST be \"DataSet\"."
       },
       "subtype": {
-         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/Coding",
+         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/MappableConcept",
          "description": "A specific type of data set the DataSet instance represents (e.g. a 'clinical data set', a 'sequencing data set', a 'gene expression data set', a 'genome annotation data set')",
          "$comment": "This attribute can be used to report a specific type for the DataSet, in cases where a model does not define DataSet subclasses for this purpose. Implementers can define their own set of data set type codes/terms, to match the needs of the domain or application."
       },

--- a/schema/core-im/json/Document
+++ b/schema/core-im/json/Document
@@ -118,7 +118,7 @@
          "description": "Must be \"Document\""
       },
       "subtype": {
-         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/Coding",
+         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/MappableConcept",
          "description": "A specific type of document that a Document instance represents (e.g.  'publication', 'patent', 'pathology report')",
          "$comment": "This attribute can be used to report a specific type for the Document, in cases where a model does not define Document subclasses for this purpose.  Implementers can define their own set of document type codes/terms, to match the needs of their application."
       },

--- a/schema/core-im/json/EvidenceLine
+++ b/schema/core-im/json/EvidenceLine
@@ -117,6 +117,10 @@
          "default": "EvidenceLine",
          "description": "Must be \"EvidenceLine\""
       },
+      "targetProposition": {
+         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/Proposition",
+         "description": "The possible fact against which evidence items contained in an Evidence Line were collectively evaluated, in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against a target proposition that the variant is pathogenic for a specific disease."
+      },
       "hasEvidenceItems": {
          "type": "array",
          "ordered": false,
@@ -155,14 +159,7 @@
          "description": "The direction of support that the Evidence Line is determined to provide toward its target Proposition (supports, disputes, neutral)"
       },
       "strengthOfEvidenceProvided": {
-         "oneOf": [
-            {
-               "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/Coding"
-            },
-            {
-               "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/IRI"
-            }
-         ],
+         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/MappableConcept",
          "description": "The strength of support that an Evidence Line is determined to provide for or against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided value.",
          "$comment": "Values of this attribute can be defined by for a given profile based on domain/application needs, but should be framed in qualitative terms (e.g. 'strong', 'moderate', 'weak'). The 'scoreOfEvidenceProvided' attribute can be used to report quantitative assessments of evidence provided."
       },

--- a/schema/core-im/json/Method
+++ b/schema/core-im/json/Method
@@ -118,7 +118,7 @@
          "description": "MUST be \"Method\"."
       },
       "subtype": {
-         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/Coding",
+         "$ref": "/ga4gh/schema/gks-common/1.x/core-im/json/MappableConcept",
          "description": "A specific type of method that a Method instance represents (e.g. 'Variant Interpretation Guideline', or 'Experimental Protocol').",
          "$comment": "This attribute can be used to report a specific type for the Method, in cases where a model does not define Method subclasses for this purpose.  Implementers can define their own set of method type codes/terms, to match the needs of their application."
       },


### PR DESCRIPTION
- added Proposition class and targetProposition attribute to support use of Evidence Lines in Functional Impact profiles
- attempted to include 'string' as an allowable data type for `EvidenceLine.strengthOfEvidenceProvided`, and `Statement.classification` - to support decisions made about FunctionalImpact profiles (but likely did this wrong and will need fixing)