### PR TITLE
update maturity models for use with VRS

### DIFF
--- a/schema/core-im/core-im-source.yaml
+++ b/schema/core-im/core-im-source.yaml
@@ -5,7 +5,7 @@ title: GKS Commons Core Information Class Definitions
 
 $defs:
   Entity:
-    maturity: draft
+    maturity: trial use
     description: Anything that exists, has existed, or will exist.
     $comment: >-
       Entity is the root class of the 'gks-common' core information model. All common classes that
@@ -985,7 +985,7 @@ $defs:
 
   Extension:
     type: object
-    maturity: draft
+    maturity: trial use
     description: >-
       The Extension class provides entities with a means to include
       additional attributes that are outside of the specified standard
@@ -1024,7 +1024,7 @@ $defs:
 
   IRI:
     type: string
-    maturity: draft
+    maturity: trial use
     description: >-
       An IRI Reference (either an IRI or a relative-reference), according to `RFC3986 section 4.1
       <https://datatracker.ietf.org/doc/html/rfc3986#section-4.1>`_ and `RFC3987 section 2.1


### PR DESCRIPTION
Move Entity, IRI, and Extension to trial use maturity for anticipated use with VRS 2.0 pre-release classes.