### PR TITLE
add strict true to enforce no additional properties

### DIFF
--- a/schema/gks-core/gks-core-source.yaml
+++ b/schema/gks-core/gks-core-source.yaml
@@ -1,6 +1,7 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 $id: "https://w3id.org/ga4gh/schema/gks-core/1.x/gks-core-source.yaml"
 title: GKS Core Class Definitions
+strict: true
 
 $defs:
   Entity:

--- a/schema/gks-core/json/Agent
+++ b/schema/gks-core/json/Agent
@@ -59,5 +59,6 @@
    },
    "required": [
       "type"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/Characteristic
+++ b/schema/gks-core/json/Characteristic
@@ -37,5 +37,6 @@
    "required": [
       "name",
       "value"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/Coding
+++ b/schema/gks-core/json/Coding
@@ -39,5 +39,6 @@
    "required": [
       "code",
       "system"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/ConceptMapping
+++ b/schema/gks-core/json/ConceptMapping
@@ -38,5 +38,6 @@
    "required": [
       "coding",
       "relation"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/Contribution
+++ b/schema/gks-core/json/Contribution
@@ -80,5 +80,6 @@
    },
    "required": [
       "type"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/DataSet
+++ b/schema/gks-core/json/DataSet
@@ -141,5 +141,6 @@
    },
    "required": [
       "type"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/Document
+++ b/schema/gks-core/json/Document
@@ -148,5 +148,6 @@
    },
    "required": [
       "type"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/Extension
+++ b/schema/gks-core/json/Extension
@@ -43,5 +43,6 @@
    "required": [
       "name",
       "value"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/MappableConcept
+++ b/schema/gks-core/json/MappableConcept
@@ -39,5 +39,6 @@
    },
    "required": [
       "label"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/Method
+++ b/schema/gks-core/json/Method
@@ -130,5 +130,6 @@
    },
    "required": [
       "type"
-   ]
+   ],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/RecordMetadata
+++ b/schema/gks-core/json/RecordMetadata
@@ -46,5 +46,6 @@
          "description": "Describes specific contributions made by an human or software agent to the creation, modification, or administrative management of a data record or object."
       }
    },
-   "required": []
+   "required": [],
+   "additionalProperties": false
 }

--- a/schema/gks-core/json/StudyGroup
+++ b/schema/gks-core/json/StudyGroup
@@ -67,5 +67,6 @@
    },
    "required": [
       "type"
-   ]
+   ],
+   "additionalProperties": false
 }


### PR DESCRIPTION
Realized that downstream tests were passing incorrectly since MappableConcept (and all gks-core classes) now allow additional properties. I don't think this was intended behavior, this PR addresses that issue by reintroducing `strict: true`