### PR TITLE
Decouple `proposition` requirement from `Statement` for profiling

### DIFF
--- a/schema/gks-core/def/EvidenceLine.rst
+++ b/schema/gks-core/def/EvidenceLine.rst
@@ -95,7 +95,7 @@ Some EvidenceLine attributes are inherited from :ref:`InformationEntity`.
       - 
       - string
       - 1..1
-      - MUST be "StateEvidenceLinement".
+      - MUST be "EvidenceLine".
    *  - targetProposition
       - 
       - :ref:`Proposition`

--- a/schema/gks-core/def/Statement.rst
+++ b/schema/gks-core/def/Statement.rst
@@ -99,7 +99,7 @@ Some Statement attributes are inherited from :ref:`InformationEntity`.
    *  - proposition
       - 
       - :ref:`Proposition`
-      - 1..1
+      - 0..1
       - A possible fact that the Statement assesses or puts forth as true.
    *  - direction
       - 

--- a/schema/gks-core/gks-core-source.yaml
+++ b/schema/gks-core/gks-core-source.yaml
@@ -625,8 +625,6 @@ $defs:
           Evidence Lines are useful in cases where a data provider wants to describe in detail how information
           was assessed as evidence to generate and score different arguments for or against a Statement's
           proposition. Evidence Lines can be omitted if such information is not available or needed.
-    required:
-      - proposition
 
   EvidenceLine:
     type: object
@@ -660,7 +658,7 @@ $defs:
         extends: type
         const: EvidenceLine
         default: EvidenceLine
-        description: MUST be "StateEvidenceLinement".    
+        description: MUST be "EvidenceLine".    
       targetProposition:
         $ref: "#/$defs/Proposition"
         description: >-

--- a/schema/gks-core/json/EvidenceLine
+++ b/schema/gks-core/json/EvidenceLine
@@ -112,7 +112,7 @@
       },
       "type": {
          "type": "string",
-         "description": "MUST be \"StateEvidenceLinement\".",
+         "description": "MUST be \"EvidenceLine\".",
          "$comment": "MUST be the label of a concrete class from the data model.",
          "const": "EvidenceLine",
          "default": "EvidenceLine"

--- a/schema/gks-core/json/Statement
+++ b/schema/gks-core/json/Statement
@@ -163,7 +163,6 @@
       }
    },
    "required": [
-      "proposition",
       "type"
    ],
    "additionalProperties": false


### PR DESCRIPTION
remove `proposition` requirement from Statement so profiled props can be used as constraints on constrained Statement recipe-like profiles.