### PR TITLE
enhance mapping relations in gks-core-source.yaml 

### DIFF
--- a/schema/gks-core/gks-core-source.yaml
+++ b/schema/gks-core/gks-core-source.yaml
@@ -164,11 +164,12 @@ $defs:
           A mapping relation between concepts as defined by the Simple Knowledge Organization System (SKOS).
         type: string
         enum:
-          - closeMatch
-          - exactMatch
-          - broadMatch
-          - narrowMatch
-          - relatedMatch
+          - skos:mappingRelation
+          - skos:closeMatch
+          - skosexactMatch
+          - skos:broadMatch
+          - skos:narrowMatch
+          - skos:relatedMatch
     required:
       - relation
       - coding


### PR DESCRIPTION
- added 'mappingRelation' to the enum - as in our ballot release review we decided to recommend use of this parent term in cases where data providers were not sure or didn't want to commit to a more specific relation. This recommendation will be included in implementation guidance on the ConceptMapping RTD page. 
- also added `skos` prefixes to the enum terms (e.g. `skos:exactMatch`) - to make it explicit that these terms come from the skos terminology, and can be explored further there.