### PR TITLE
gks-core 1.0 product release PR

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -2,5 +2,5 @@ pytest
 jsonschema
 referencing
 pyyaml
-ga4gh.gks.metaschema==0.3.1
+ga4gh.gks.metaschema==0.3.2
 pre-commit

--- a/schema/gks-core/gks-core-source.yaml
+++ b/schema/gks-core/gks-core-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/gks-core-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/gks-core/1.0/gks-core-source.yaml"
 title: GKS Core Class Definitions
 strict: true
 

--- a/schema/gks-core/json/Code
+++ b/schema/gks-core/json/Code
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/code",
+   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0/json/code",
    "title": "code",
    "type": "string",
    "maturity": "trial use",

--- a/schema/gks-core/json/Coding
+++ b/schema/gks-core/json/Coding
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/Coding",
+   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0/json/Coding",
    "title": "Coding",
    "type": "object",
    "maturity": "trial use",
@@ -14,7 +14,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -32,14 +32,14 @@
          "description": "Version of the terminology or code system that provided the code."
       },
       "code": {
-         "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/code",
+         "$ref": "/ga4gh/schema/gks-core/1.0/json/code",
          "description": "A symbol uniquely identifying the concept, as in a syntax defined by the code system. e.g. 'civic.did:30', 'MONDO:005061', and 'C3512' are codes defined by different systems for representing the concept of 'lung adenocarcinoma'.  If a dereferencable identifier is available for the code, it should be provided in the `iris` field."
       },
       "iris": {
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/iriReference"
+            "$ref": "/ga4gh/schema/gks-core/1.0/json/iriReference"
          },
          "description": "A list of IRIs that are associated with the coding. This can be used to provide additional context or to link to additional information about the concept."
       }

--- a/schema/gks-core/json/ConceptMapping
+++ b/schema/gks-core/json/ConceptMapping
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/ConceptMapping",
+   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0/json/ConceptMapping",
    "title": "ConceptMapping",
    "type": "object",
    "maturity": "trial use",
@@ -14,13 +14,13 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
       },
       "coding": {
-         "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/Coding",
+         "$ref": "/ga4gh/schema/gks-core/1.0/json/Coding",
          "description": "A structured representation of a code for a defined concept in a terminology or code system."
       },
       "relation": {

--- a/schema/gks-core/json/Extension
+++ b/schema/gks-core/json/Extension
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/Extension",
+   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0/json/Extension",
    "title": "Extension",
    "type": "object",
    "maturity": "trial use",
@@ -14,7 +14,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/gks-core/json/MappableConcept
+++ b/schema/gks-core/json/MappableConcept
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/MappableConcept",
+   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0/json/MappableConcept",
    "title": "MappableConcept",
    "type": "object",
    "maturity": "trial use",
@@ -14,7 +14,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -29,14 +29,14 @@
          "description": "A primary name for the concept."
       },
       "primaryCoding": {
-         "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/Coding",
+         "$ref": "/ga4gh/schema/gks-core/1.0/json/Coding",
          "description": "A primary coding for the concept."
       },
       "mappings": {
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/ConceptMapping"
+            "$ref": "/ga4gh/schema/gks-core/1.0/json/ConceptMapping"
          },
          "description": "A list of mappings to concepts in terminologies or code systems. Each mapping should include a coding and a relation."
       }

--- a/schema/gks-core/json/date
+++ b/schema/gks-core/json/date
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/date",
+   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0/json/date",
    "title": "date",
    "type": "string",
    "maturity": "trial use",

--- a/schema/gks-core/json/datetime
+++ b/schema/gks-core/json/datetime
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/datetime",
+   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0/json/datetime",
    "title": "datetime",
    "type": "string",
    "maturity": "trial use",

--- a/schema/gks-core/json/iriReference
+++ b/schema/gks-core/json/iriReference
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.4/json/iriReference",
+   "$id": "https://w3id.org/ga4gh/schema/gks-core/1.0/json/iriReference",
    "title": "iriReference",
    "type": "string",
    "maturity": "trial use",


### PR DESCRIPTION
After copying the 1.0.0-snapshot.2025-02 branch to a new 1.0 branch. I created this PR which simply changed the schema ids from `1.0.0-snapshot.2025-02.4` to `1.0` and reran the MSP to regen new json files and then reran the tests to verify. 

Once this is approved we will cut the 1.0 official release for this product based on it.